### PR TITLE
Update link to adferrand docs

### DIFF
--- a/docker-compose.letsencrypt.yml
+++ b/docker-compose.letsencrypt.yml
@@ -9,7 +9,7 @@ services:
       - LETSENCRYPT_STAGING=${LETSENCRYPT_STAGING:-false}
       - LETSENCRYPT_USER_MAIL=${LETSENCRYPT_USER_MAIL:?LETSENCRYPT_USER_MAIL is not set or empty}
       # if you don't use Cloudflare as your DNS provider, change these as necessary
-      # https://github.com/adferrand/docker-letsencrypt-dns#configuring-dns-provider-and-authentication-to-dns-api
+      # https://github.com/adferrand/dnsrobocert/blob/legacy/README.md#configuring-dns-provider-and-authentication-to-dns-api
       - LEXICON_CLOUDFLARE_AUTH_TOKEN=${LEXICON_CLOUDFLARE_AUTH_TOKEN:?LEXICON_CLOUDFLARE_AUTH_TOKEN is not set or empty}
       - LEXICON_CLOUDFLARE_AUTH_USERNAME=${LEXICON_CLOUDFLARE_AUTH_USERNAME:?LEXICON_CLOUDFLARE_AUTH_USERNAME is not set or empty}
       - LEXICON_PROVIDER=cloudflare


### PR DESCRIPTION
...cause the old link doesn't work anymore.

This is just a workaround to get the documentation for the old but used version of adferrand/letsencrypt-dns.
As long as docker-compose-prod is not migrated to use adferrand/dnsrobocert >=3 this is better than nothing:)

PS: I hope this is the correct repository to create the PR in.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | api-platform/docs#...
